### PR TITLE
fix(v2): publish add event in `AddChannelEmote`

### DIFF
--- a/internal/gql/v2/resolvers/mutation/mutation.user-emotes.go
+++ b/internal/gql/v2/resolvers/mutation/mutation.user-emotes.go
@@ -61,7 +61,7 @@ func (r *Resolver) AddChannelEmote(ctx context.Context, channelIDArg, emoteIDArg
 	}
 
 	go func() {
-		if err := events.PublishLegacyEventAPI(r.Ctx, model3.ListItemActionUpdate, twConn.Data.Login, *actor, esb.EmoteSet, emote); err != nil {
+		if err := events.PublishLegacyEventAPI(r.Ctx, model3.ListItemActionAdd, twConn.Data.Login, *actor, esb.EmoteSet, emote); err != nil {
 			zap.S().Errorw("redis",
 				"error", err,
 			)


### PR DESCRIPTION
Publishing an `update` event is wrong in this case, since the emote is added.