### PR TITLE
feat: add user-by-connection query

### DIFF
--- a/internal/gql/v3/resolvers/query/query.users.go
+++ b/internal/gql/v3/resolvers/query/query.users.go
@@ -86,7 +86,7 @@ func (r *Resolver) Users(ctx context.Context, queryArg string, pageArg *int, lim
 }
 
 func (r *Resolver) UserByConnection(ctx context.Context, connectionId string) (*model.User, error) {
-	user, err := r.Ctx.Inst().Query.Users(ctx, bson.M{"connections.id": strings.ToLower(connectionId)}).First()
+	user, err := r.Ctx.Inst().Loaders.UserByConnectionID().Load(strings.ToLower(connectionId))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gql/v3/resolvers/query/query.users.go
+++ b/internal/gql/v3/resolvers/query/query.users.go
@@ -2,7 +2,6 @@ package query
 
 import (
 	"context"
-	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/seventv/api/internal/gql/v3/auth"
@@ -85,8 +84,12 @@ func (r *Resolver) Users(ctx context.Context, queryArg string, pageArg *int, lim
 	return result, err
 }
 
-func (r *Resolver) UserByConnection(ctx context.Context, connectionId string) (*model.User, error) {
-	user, err := r.Ctx.Inst().Loaders.UserByConnectionID().Load(strings.ToLower(connectionId))
+func (r *Resolver) UserByConnection(ctx context.Context, connectionPlatform model.ConnectionPlatform, id string) (*model.User, error) {
+	l, ok := r.Ctx.Inst().Loaders.UserByConnectionID(structures.UserConnectionPlatform(connectionPlatform))
+	if !ok {
+		return nil, errors.ErrInvalidRequest().SetDetail("Unknown connection platform")
+	}
+	user, err := l.Load(id)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gql/v3/resolvers/query/query.users.go
+++ b/internal/gql/v3/resolvers/query/query.users.go
@@ -89,6 +89,7 @@ func (r *Resolver) UserByConnection(ctx context.Context, connectionPlatform mode
 	if !ok {
 		return nil, errors.ErrInvalidRequest().SetDetail("Unknown connection platform")
 	}
+
 	user, err := l.Load(id)
 	if err != nil {
 		return nil, err

--- a/internal/gql/v3/schema/users.gql
+++ b/internal/gql/v3/schema/users.gql
@@ -2,7 +2,7 @@ extend type Query {
   actor: User
   user(id: ObjectID!): User!
   usersByID(list: [ObjectID!]!): [UserPartial!]!
-  userByConnection(id: String!): User!
+  userByConnection(platform: ConnectionPlatform!, id: String!): User!
   users(query: String!, page: Int, limit: Int): [UserPartial!]!
 }
 

--- a/internal/gql/v3/schema/users.gql
+++ b/internal/gql/v3/schema/users.gql
@@ -2,6 +2,7 @@ extend type Query {
   actor: User
   user(id: ObjectID!): User!
   usersByID(list: [ObjectID!]!): [UserPartial!]!
+  userByConnection(id: String!): User!
   users(query: String!, page: Int, limit: Int): [UserPartial!]!
 }
 

--- a/internal/loaders/loaders.go
+++ b/internal/loaders/loaders.go
@@ -17,6 +17,7 @@ const LoadersKey = utils.Key("dataloaders")
 type Instance interface {
 	UserByID() UserLoaderByID
 	UserByUsername() UserLoaderByUsername
+	UserByConnectionID() UserByConnectionID
 	EmoteByID() EmoteLoaderByID
 	EmoteByOwnerID() BatchEmoteLoaderByID
 	EmoteSetByID() EmoteSetLoaderByID
@@ -25,8 +26,9 @@ type Instance interface {
 
 type inst struct {
 	// User Loaders
-	userByID       UserLoaderByID
-	userByUsername UserLoaderByUsername
+	userByID           UserLoaderByID
+	userByUsername     UserLoaderByUsername
+	userByConnectionID UserByConnectionID
 
 	// Emote Loaders
 	emoteByID      EmoteLoaderByID
@@ -52,6 +54,7 @@ func New(ctx context.Context, mngo mongo.Instance, rdis redis.Instance, quer *qu
 
 	l.userByID = userLoader[primitive.ObjectID](ctx, l, "_id")
 	l.userByUsername = userLoader[string](ctx, l, "username")
+	l.userByConnectionID = userLoader[string](ctx, l, "connection.id")
 	l.emoteByID = emoteLoader(ctx, l, "versions.id")
 	l.emoteByOwnerID = batchEmoteLoader(ctx, l, "owner_id")
 	l.emoteSetByID = emoteSetByID(ctx, l)
@@ -66,6 +69,10 @@ func (l inst) UserByID() UserLoaderByID {
 
 func (l inst) UserByUsername() UserLoaderByUsername {
 	return l.userByUsername
+}
+
+func (l inst) UserByConnectionID() UserByConnectionID {
+	return l.userByConnectionID
 }
 
 func (l inst) EmoteByID() EmoteLoaderByID {
@@ -88,6 +95,7 @@ func (l *inst) EmoteByOwnerID() BatchEmoteLoaderByID {
 type (
 	UserLoaderByID          = *dataloader.DataLoader[primitive.ObjectID, structures.User]
 	UserLoaderByUsername    = *dataloader.DataLoader[string, structures.User]
+	UserByConnectionID      = *dataloader.DataLoader[string, structures.User]
 	EmoteLoaderByID         = *dataloader.DataLoader[primitive.ObjectID, structures.Emote]
 	BatchEmoteLoaderByID    = *dataloader.DataLoader[primitive.ObjectID, []structures.Emote]
 	EmoteSetLoaderByID      = *dataloader.DataLoader[primitive.ObjectID, structures.EmoteSet]

--- a/internal/loaders/user.loader.go
+++ b/internal/loaders/user.loader.go
@@ -42,16 +42,62 @@ func userLoader[T comparable](ctx context.Context, x inst, keyName string) *data
 					case "username":
 						v, _ := utils.ToAny(u.Username).(T)
 						m[v] = u
-					case "connection.id":
-						for _, c := range u.Connections {
-							if c.ID != "" {
-								v, _ := utils.ToAny(c.ID).(T)
-								m[v] = u
-							}
-						}
 					default:
 						v, _ := utils.ToAny(u.ID).(T)
 						m[v] = u
+					}
+				}
+
+				for i, v := range keys {
+					if x, ok := m[v]; ok {
+						items[i] = x
+					} else {
+						errs[i] = errors.ErrUnknownUser()
+					}
+				}
+			} else {
+				for i := range errs {
+					errs[i] = err
+				}
+			}
+
+			return items, errs
+		},
+	})
+}
+
+func userByConnectionLoader(ctx context.Context, x inst, platform structures.UserConnectionPlatform) *dataloader.DataLoader[string, structures.User] {
+	return dataloader.New(dataloader.Config[string, structures.User]{
+		Wait: time.Millisecond * 25,
+		Fetch: func(keys []string) ([]structures.User, []error) {
+			ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+			defer cancel()
+
+			items := make([]structures.User, len(keys))
+			errs := make([]error, len(keys))
+
+			// Initially fill the response with deleted emotes in case some cannot be found
+			for i := 0; i < len(items); i++ {
+				items[i] = structures.DeletedUser
+			}
+
+			// Fetch users
+			result := x.query.Users(ctx, bson.M{
+				"connections.id":       bson.M{"$in": keys},
+				"connections.platform": platform,
+			})
+			if result.Empty() {
+				return items, errs
+			}
+			users, err := result.Items()
+
+			if err == nil {
+				m := make(map[string]structures.User)
+				for _, u := range users {
+					for _, c := range u.Connections {
+						if c.Platform == platform {
+							m[c.ID] = u
+						}
 					}
 				}
 

--- a/internal/loaders/user.loader.go
+++ b/internal/loaders/user.loader.go
@@ -42,6 +42,13 @@ func userLoader[T comparable](ctx context.Context, x inst, keyName string) *data
 					case "username":
 						v, _ := utils.ToAny(u.Username).(T)
 						m[v] = u
+					case "connection.id":
+						for _, c := range u.Connections {
+							if c.ID != "" {
+								v, _ := utils.ToAny(c.ID).(T)
+								m[v] = u
+							}
+						}
 					default:
 						v, _ := utils.ToAny(u.ID).(T)
 						m[v] = u


### PR DESCRIPTION
This is an attempt to add a query that gets a user by its connection-id.

It's basically the `user` query from v2 mixed with the one from v3.

Fixes #65 

![](https://cdn.7tv.app/emote/60b14a737a157a7f3360fb32/1x) _I can't test it but at least it builds_