### PR TITLE
Optimize User & Emote Queries

### DIFF
--- a/data/query/query.emote.go
+++ b/data/query/query.emote.go
@@ -2,7 +2,6 @@ package query
 
 import (
 	"context"
-	"time"
 
 	"github.com/seventv/common/mongo"
 	"github.com/seventv/common/structures/v3"
@@ -32,7 +31,7 @@ func (q *Query) Emotes(ctx context.Context, filter bson.M) *QueryResult[structur
 			Key:   "$match",
 			Value: filter,
 		}},
-	}, options.MergeAggregateOptions().SetBatchSize(25).SetMaxAwaitTime(time.Second*30))
+	}, options.MergeAggregateOptions().SetBatchSize(15))
 	if err != nil {
 		zap.S().Errorw("failed to create query to aggregate emotes", "error", err)
 

--- a/data/query/query.emote.go
+++ b/data/query/query.emote.go
@@ -8,13 +8,14 @@ import (
 	"github.com/seventv/common/utils"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.uber.org/zap"
 )
 
 func (q *Query) Emotes(ctx context.Context, filter bson.M) *QueryResult[structures.Emote] {
 	qr := QueryResult[structures.Emote]{}
 
-	cur, err := q.mongo.Collection(mongo.CollectionNameEmotes).Find(ctx, filter)
+	cur, err := q.mongo.Collection(mongo.CollectionNameEmotes).Find(ctx, filter, options.Find().SetNoCursorTimeout(true))
 	if err != nil {
 		zap.S().Errorw("failed to create query to aggregate emotes", "error", err)
 

--- a/data/query/query.emote.go
+++ b/data/query/query.emote.go
@@ -8,14 +8,13 @@ import (
 	"github.com/seventv/common/utils"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.uber.org/zap"
 )
 
 func (q *Query) Emotes(ctx context.Context, filter bson.M) *QueryResult[structures.Emote] {
 	qr := QueryResult[structures.Emote]{}
 
-	cur, err := q.mongo.Collection(mongo.CollectionNameEmotes).Find(ctx, filter, options.Find().SetBatchSize(5))
+	cur, err := q.mongo.Collection(mongo.CollectionNameEmotes).Find(ctx, filter)
 	if err != nil {
 		zap.S().Errorw("failed to create query to aggregate emotes", "error", err)
 

--- a/data/query/query.emote.go
+++ b/data/query/query.emote.go
@@ -2,12 +2,14 @@ package query
 
 import (
 	"context"
+	"time"
 
 	"github.com/seventv/common/mongo"
 	"github.com/seventv/common/structures/v3"
 	"github.com/seventv/common/utils"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.uber.org/zap"
 )
 
@@ -30,7 +32,7 @@ func (q *Query) Emotes(ctx context.Context, filter bson.M) *QueryResult[structur
 			Key:   "$match",
 			Value: filter,
 		}},
-	})
+	}, options.MergeAggregateOptions().SetBatchSize(25).SetMaxAwaitTime(time.Second*30))
 	if err != nil {
 		zap.S().Errorw("failed to create query to aggregate emotes", "error", err)
 

--- a/data/query/query.emote.go
+++ b/data/query/query.emote.go
@@ -15,7 +15,7 @@ import (
 func (q *Query) Emotes(ctx context.Context, filter bson.M) *QueryResult[structures.Emote] {
 	qr := QueryResult[structures.Emote]{}
 
-	cur, err := q.mongo.Collection(mongo.CollectionNameEmotes).Find(ctx, filter, options.Find().SetNoCursorTimeout(true))
+	cur, err := q.mongo.Collection(mongo.CollectionNameEmotes).Find(ctx, filter, options.Find().SetNoCursorTimeout(true).SetBatchSize(10))
 	if err != nil {
 		zap.S().Errorw("failed to create query to aggregate emotes", "error", err)
 

--- a/data/query/query.search-users.go
+++ b/data/query/query.search-users.go
@@ -81,11 +81,6 @@ type UserSearchOptions struct {
 	Query string
 	Sort  bson.M
 }
-type aggregatedUsersResult struct {
-	Users            []structures.User                  `bson:"users"`
-	RoleEntitlements []structures.Entitlement[bson.Raw] `bson:"role_entitlements"`
-	TotalCount       int                                `bson:"total_count"`
-}
 
 func (q *Query) UserEditorOf(ctx context.Context, id primitive.ObjectID) ([]structures.UserEditor, error) {
 	cur, err := q.mongo.Collection(mongo.CollectionNameUsers).Aggregate(ctx, mongo.Pipeline{

--- a/data/query/query.users.go
+++ b/data/query/query.users.go
@@ -2,15 +2,14 @@ package query
 
 import (
 	"context"
-	"io"
-	"time"
 
 	"github.com/seventv/common/errors"
 	"github.com/seventv/common/mongo"
 	"github.com/seventv/common/structures/v3"
+	"github.com/seventv/common/utils"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.uber.org/zap"
 )
 
 func (q *Query) Users(ctx context.Context, filter bson.M) *QueryResult[structures.User] {
@@ -39,71 +38,78 @@ func (q *Query) Users(ctx context.Context, filter bson.M) *QueryResult[structure
 				}},
 			},
 		}},
-		{{
-			Key: "$group",
-			Value: bson.M{
-				"_id": nil,
-				"users": bson.M{
-					"$push": "$$ROOT",
-				},
-			},
-		}},
-		{{
-			Key: "$lookup",
-			Value: mongo.Lookup{
-				From:         mongo.CollectionNameEntitlements,
-				LocalField:   "users._id",
-				ForeignField: "user_id",
-				As:           "role_entitlements",
-			},
-		}},
-		{{
-			Key: "$set",
-			Value: bson.M{
-				"role_entitlements": bson.M{
-					"$filter": bson.M{
-						"input": "$role_entitlements",
-						"as":    "ent",
-						"cond": bson.M{
-							"$eq": bson.A{"$$ent.kind", structures.EntitlementKindRole},
-						},
-					},
-				},
-			},
-		}},
-	}, options.Aggregate().SetBatchSize(25).SetMaxAwaitTime(time.Second*30))
+	})
 	if err != nil {
-		return r.setError(errors.ErrInternalServerError().SetDetail(err.Error()))
-	}
-
-	// Get roles
-	roleMap := make(map[primitive.ObjectID]structures.Role)
-	roles, _ := q.Roles(ctx, bson.M{})
-
-	for _, role := range roles {
-		roleMap[role.ID] = role
-	}
-
-	// Map all objects
-	cur.Next(ctx)
-
-	v := &aggregatedUsersResult{}
-	if err = cur.Decode(v); err != nil {
-		if err == io.EOF {
-			return r.setError(errors.ErrNoItems())
-		}
+		zap.S().Errorw("failed to create query to aggregate users", "error", err)
 
 		return r.setError(errors.ErrInternalServerError().SetDetail(err.Error()))
 	}
 
-	qb := &QueryBinder{ctx, q}
+	users := []structures.User{}
 
-	userMap, err := qb.MapUsers(v.Users, v.RoleEntitlements...)
+	if err := cur.All(ctx, &users); err != nil {
+		zap.S().Errorw("failed to decode users", "error", err)
+
+		return r.setError(errors.ErrInternalServerError().SetDetail(err.Error()))
+	}
+
+	// Map all users
+	userMap := map[primitive.ObjectID]structures.User{}
+	for _, u := range users {
+		userMap[u.ID] = u
+	}
+
+	entitlements, err := q.Entitlements(ctx, bson.M{"user_id": bson.M{
+		"$in": utils.Map(users, func(x structures.User) primitive.ObjectID {
+			return x.ID
+		}),
+	}}).Items()
 	if err != nil {
 		return r.setError(err)
 	}
 
+	roles, err := q.Roles(ctx, bson.M{})
+	if err != nil {
+		zap.S().Errorw("failed to fetch roles", "error", err)
+		r.setError(err)
+
+		return r
+	}
+
+	var defaultRoleID primitive.ObjectID
+
+	roleMap := make(map[primitive.ObjectID]structures.Role)
+	for _, r := range roles {
+		roleMap[r.ID] = r
+
+		if r.Default {
+			defaultRoleID = r.ID
+		}
+	}
+
+	entMap := make(map[primitive.ObjectID]EntitlementQueryResult)
+	for _, e := range entitlements {
+		entMap[e.UserID] = e
+	}
+
 	for _, u := range userMap {
+		ents := entMap[u.ID]
+
+		roleIDs := make(utils.Set[primitive.ObjectID])
+		roleIDs.Add(defaultRoleID)
+		roleIDs.Fill(append(
+			utils.Map(ents.Roles, func(x structures.Entitlement[structures.EntitlementDataRole]) primitive.ObjectID {
+				return x.Data.RefID
+			}),
+			u.RoleIDs...,
+		)...)
+
+		for _, roleID := range roleIDs.Values() {
+			if role, ok := roleMap[roleID]; ok {
+				u.Roles = append(u.Roles, role)
+			}
+		}
+
 		items = append(items, u)
 	}
 

--- a/data/query/query.users.go
+++ b/data/query/query.users.go
@@ -9,7 +9,6 @@ import (
 	"github.com/seventv/common/utils"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.uber.org/zap"
 )
 
@@ -17,7 +16,7 @@ func (q *Query) Users(ctx context.Context, filter bson.M) *QueryResult[structure
 	items := []structures.User{}
 	r := &QueryResult[structures.User]{}
 
-	cur, err := q.mongo.Collection(mongo.CollectionNameUsers).Find(ctx, filter, options.Find().SetBatchSize(25))
+	cur, err := q.mongo.Collection(mongo.CollectionNameUsers).Find(ctx, filter)
 	if err != nil {
 		zap.S().Errorw("failed to create query to aggregate users", "error", err)
 

--- a/data/query/query.users.go
+++ b/data/query/query.users.go
@@ -17,7 +17,7 @@ func (q *Query) Users(ctx context.Context, filter bson.M) *QueryResult[structure
 	items := []structures.User{}
 	r := &QueryResult[structures.User]{}
 
-	cur, err := q.mongo.Collection(mongo.CollectionNameUsers).Find(ctx, filter, options.Find().SetNoCursorTimeout(true))
+	cur, err := q.mongo.Collection(mongo.CollectionNameUsers).Find(ctx, filter, options.Find().SetNoCursorTimeout(true).SetBatchSize(10))
 	if err != nil {
 		zap.S().Errorw("failed to create query to aggregate users", "error", err)
 

--- a/data/query/query.users.go
+++ b/data/query/query.users.go
@@ -9,6 +9,7 @@ import (
 	"github.com/seventv/common/utils"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.uber.org/zap"
 )
 
@@ -16,7 +17,7 @@ func (q *Query) Users(ctx context.Context, filter bson.M) *QueryResult[structure
 	items := []structures.User{}
 	r := &QueryResult[structures.User]{}
 
-	cur, err := q.mongo.Collection(mongo.CollectionNameUsers).Find(ctx, filter)
+	cur, err := q.mongo.Collection(mongo.CollectionNameUsers).Find(ctx, filter, options.Find().SetNoCursorTimeout(true))
 	if err != nil {
 		zap.S().Errorw("failed to create query to aggregate users", "error", err)
 

--- a/data/query/query.users.go
+++ b/data/query/query.users.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"time"
 
 	"github.com/seventv/common/errors"
 	"github.com/seventv/common/mongo"
@@ -9,6 +10,7 @@ import (
 	"github.com/seventv/common/utils"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.uber.org/zap"
 )
 
@@ -38,7 +40,7 @@ func (q *Query) Users(ctx context.Context, filter bson.M) *QueryResult[structure
 				}},
 			},
 		}},
-	})
+	}, options.Aggregate().SetBatchSize(5).SetMaxAwaitTime(time.Second*30))
 	if err != nil {
 		zap.S().Errorw("failed to create query to aggregate users", "error", err)
 

--- a/data/query/query.users.go
+++ b/data/query/query.users.go
@@ -2,7 +2,6 @@ package query
 
 import (
 	"context"
-	"time"
 
 	"github.com/seventv/common/errors"
 	"github.com/seventv/common/mongo"
@@ -40,7 +39,7 @@ func (q *Query) Users(ctx context.Context, filter bson.M) *QueryResult[structure
 				}},
 			},
 		}},
-	}, options.Aggregate().SetBatchSize(5).SetMaxAwaitTime(time.Second*30))
+	}, options.Aggregate().SetBatchSize(5))
 	if err != nil {
 		zap.S().Errorw("failed to create query to aggregate users", "error", err)
 

--- a/internal/loaders/emote.loader.go
+++ b/internal/loaders/emote.loader.go
@@ -13,7 +13,7 @@ import (
 func emoteLoader(ctx context.Context, x inst, key string) EmoteLoaderByID {
 	return dataloader.New(dataloader.Config[primitive.ObjectID, structures.Emote]{
 		Wait:     time.Millisecond * 25,
-		MaxBatch: 500,
+		MaxBatch: 250,
 		Fetch: func(keys []primitive.ObjectID) ([]structures.Emote, []error) {
 			ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 			defer cancel()

--- a/internal/loaders/emote.loader.go
+++ b/internal/loaders/emote.loader.go
@@ -12,7 +12,8 @@ import (
 
 func emoteLoader(ctx context.Context, x inst, key string) EmoteLoaderByID {
 	return dataloader.New(dataloader.Config[primitive.ObjectID, structures.Emote]{
-		Wait: time.Millisecond * 25,
+		Wait:     time.Millisecond * 25,
+		MaxBatch: 500,
 		Fetch: func(keys []primitive.ObjectID) ([]structures.Emote, []error) {
 			ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 			defer cancel()

--- a/internal/loaders/emoteset.loader.go
+++ b/internal/loaders/emoteset.loader.go
@@ -14,7 +14,8 @@ import (
 
 func emoteSetByID(ctx context.Context, x inst) EmoteSetLoaderByID {
 	return dataloader.New(dataloader.Config[primitive.ObjectID, structures.EmoteSet]{
-		Wait: time.Millisecond * 25,
+		Wait:     time.Millisecond * 100,
+		MaxBatch: 20,
 		Fetch: func(keys []primitive.ObjectID) ([]structures.EmoteSet, []error) {
 			ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 			defer cancel()

--- a/internal/loaders/user.loader.go
+++ b/internal/loaders/user.loader.go
@@ -72,7 +72,7 @@ func userLoader[T comparable](ctx context.Context, x inst, keyName string) *data
 
 func userByConnectionLoader(ctx context.Context, x inst, platform structures.UserConnectionPlatform, key string) *dataloader.DataLoader[string, structures.User] {
 	return dataloader.New(dataloader.Config[string, structures.User]{
-		Wait:     time.Millisecond * 75,
+		Wait:     time.Millisecond * 25,
 		MaxBatch: 500,
 		Fetch: func(keys []string) ([]structures.User, []error) {
 			ctx, cancel := context.WithTimeout(ctx, time.Second*10)

--- a/internal/loaders/user.loader.go
+++ b/internal/loaders/user.loader.go
@@ -17,7 +17,7 @@ import (
 func userLoader[T comparable](ctx context.Context, x inst, keyName string) *dataloader.DataLoader[T, structures.User] {
 	return dataloader.New(dataloader.Config[T, structures.User]{
 		Wait:     time.Millisecond * 25,
-		MaxBatch: 500,
+		MaxBatch: 250,
 		Fetch: func(keys []T) ([]structures.User, []error) {
 			ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 			defer cancel()

--- a/internal/loaders/user.loader.go
+++ b/internal/loaders/user.loader.go
@@ -16,7 +16,7 @@ import (
 
 func userLoader[T comparable](ctx context.Context, x inst, keyName string) *dataloader.DataLoader[T, structures.User] {
 	return dataloader.New(dataloader.Config[T, structures.User]{
-		Wait:     time.Millisecond * 25,
+		Wait:     time.Millisecond * 50,
 		MaxBatch: 250,
 		Fetch: func(keys []T) ([]structures.User, []error) {
 			ctx, cancel := context.WithTimeout(ctx, time.Second*10)
@@ -72,8 +72,8 @@ func userLoader[T comparable](ctx context.Context, x inst, keyName string) *data
 
 func userByConnectionLoader(ctx context.Context, x inst, platform structures.UserConnectionPlatform, key string) *dataloader.DataLoader[string, structures.User] {
 	return dataloader.New(dataloader.Config[string, structures.User]{
-		Wait:     time.Millisecond * 25,
-		MaxBatch: 500,
+		Wait:     time.Millisecond * 50,
+		MaxBatch: 250,
 		Fetch: func(keys []string) ([]structures.User, []error) {
 			ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 			defer cancel()
@@ -137,7 +137,8 @@ func userByConnectionLoader(ctx context.Context, x inst, platform structures.Use
 
 func entitlementsLoader(ctx context.Context, x inst) *dataloader.DataLoader[primitive.ObjectID, query.EntitlementQueryResult] {
 	return dataloader.New(dataloader.Config[primitive.ObjectID, query.EntitlementQueryResult]{
-		Wait: time.Millisecond * 100,
+		Wait:     time.Millisecond * 100,
+		MaxBatch: 250,
 		Fetch: func(keys []primitive.ObjectID) ([]query.EntitlementQueryResult, []error) {
 			ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 			defer cancel()


### PR DESCRIPTION
Making the internal queries more efficient by streaming the results instead of returning everything at once. This should avoid hitting internal limits when issuing large batched dataloading requests.