### PR TITLE
fix: unconditional v2 cosmetics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/h2non/filetype v1.1.3
 	github.com/json-iterator/go v1.1.12
 	github.com/prometheus/client_golang v1.14.0
-	github.com/seventv/common v0.0.0-20230116115249-f964594e763d
+	github.com/seventv/common v0.0.0-20230129155616-db9a592960b7
 	github.com/seventv/compactdisc v0.0.0-20221006190906-ccfe99954e48
 	github.com/seventv/image-processor/go v0.0.0-20221128171540-d050701ac324
 	github.com/seventv/message-queue/go v0.0.0-20220721124044-9fd23bda9643

--- a/go.sum
+++ b/go.sum
@@ -342,6 +342,8 @@ github.com/seventv/common v0.0.0-20230107175235-62dbd2e54c8e h1:8xWDsQCuh3nsTOzB
 github.com/seventv/common v0.0.0-20230107175235-62dbd2e54c8e/go.mod h1:jHHFe3uNMyzb/ReDqMvaI/A1euvV/PW/G+2PhcWQqWw=
 github.com/seventv/common v0.0.0-20230116115249-f964594e763d h1:ZdWCERo0DafeXbl+6vuh7qb8C4alVxBJSoiZoQrJOMs=
 github.com/seventv/common v0.0.0-20230116115249-f964594e763d/go.mod h1:jHHFe3uNMyzb/ReDqMvaI/A1euvV/PW/G+2PhcWQqWw=
+github.com/seventv/common v0.0.0-20230129155616-db9a592960b7 h1:pbD9Xv3JLcODGTDiIaAW9ZmASatd1vuwUl/klf0l/Ww=
+github.com/seventv/common v0.0.0-20230129155616-db9a592960b7/go.mod h1:jHHFe3uNMyzb/ReDqMvaI/A1euvV/PW/G+2PhcWQqWw=
 github.com/seventv/compactdisc v0.0.0-20221006190906-ccfe99954e48 h1:IqWrtt/yob45YnOQ5Wwkbf8qP22eKVtg0WzfyEkGnFg=
 github.com/seventv/compactdisc v0.0.0-20221006190906-ccfe99954e48/go.mod h1:T+ldp0YQe03s44+A5HHHI/jB3ZmWqOIaNouEqAS+1Dk=
 github.com/seventv/image-processor/go v0.0.0-20221128171540-d050701ac324 h1:iU3wWepRTbkNoTAPR23m6TAW6Yb9pOMCYVr0K++OBAw=

--- a/internal/api/rest/v2/routes/cosmetics/cosmetics.go
+++ b/internal/api/rest/v2/routes/cosmetics/cosmetics.go
@@ -229,8 +229,8 @@ func (r *Route) generateCosmeticsData(ctx *rest.Ctx, idType string) (*model.Cosm
 	ents := make(map[structures.EntitlementKind][]structures.Entitlement[bson.Raw])
 
 	for _, ent := range entitlements {
-		if ent.Kind != structures.EntitlementKindRole && len(ent.Condition.AllRoles) == 0 {
-			continue // skip condition-less entitlements
+		if ent.Condition.NoLegacy {
+			continue
 		}
 
 		a := ents[ent.Kind]

--- a/internal/svc/presences/presences.fanout.go
+++ b/internal/svc/presences/presences.fanout.go
@@ -143,7 +143,7 @@ func (p *inst) ChannelPresenceFanout(ctx context.Context, presence structures.Us
 			eb := structures.NewEntitlementBuilder(structures.Entitlement[structures.EntitlementDataPaint]{}).
 				SetKind(structures.EntitlementKindPaint).
 				SetUserID(presence.UserID).
-				SetCondition(structures.EntitlementCondition{}).
+				SetCondition(structures.EntitlementCondition{NoLegacy: true}).
 				SetData(structures.EntitlementDataPaint{
 					RefID:    paintID,
 					Selected: len(cosmetics.Paints) == 0, // only select if user has no paints


### PR DESCRIPTION
fixing an issue which prevented entitled cosmetics with no conditions (i.e special badges such as moderator, contributor) from showing in the legacy cosmetics endpoint.