### PR TITLE
Bridge Presence Command & Private Presence

### DIFF
--- a/data/events/payload.go
+++ b/data/events/payload.go
@@ -108,8 +108,9 @@ type EndOfStreamPayload struct {
 }
 
 type BridgedCommandPayload[T BridgedCommandBody] struct {
-	Command   string `json:"command"`
-	SessionID string `json:"sid"`
-	ClientIP  string `json:"ip"`
-	Body      T      `json:"body"`
+	Command   string             `json:"command"`
+	SessionID string             `json:"sid"`
+	ClientIP  string             `json:"ip"`
+	ActorID   primitive.ObjectID `json:"actor_id"`
+	Body      T                  `json:"body"`
 }

--- a/data/events/payload_commands.go
+++ b/data/events/payload_commands.go
@@ -3,15 +3,24 @@ package events
 import (
 	"encoding/json"
 
+	"github.com/seventv/api/data/model"
 	"github.com/seventv/common/structures/v3"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type BridgedCommandBody interface {
-	json.RawMessage | UserStateCommandBody
+	json.RawMessage | UserStateCommandBody | PresenceCommandBody
 }
 
 type UserStateCommandBody struct {
 	Platform    structures.UserConnectionPlatform `json:"platform"`
 	Identifiers []string                          `json:"identifiers"`
 	Kinds       []structures.CosmeticKind         `json:"kinds"`
+}
+
+type PresenceCommandBody struct {
+	Kind   model.PresenceKind `json:"kind"`
+	Data   json.RawMessage    `json:"data"`
+	UserID primitive.ObjectID `json:"user_id"`
+	Self   bool               `json:"self"`
 }

--- a/internal/api/eventbridge/eventbridge.go
+++ b/internal/api/eventbridge/eventbridge.go
@@ -16,7 +16,7 @@ const SESSION_ID_KEY = utils.Key("session_id")
 func handle(gctx global.Context, name string, body []byte) error {
 	var err error
 
-	req := getCommandBody[events.UserStateCommandBody](body)
+	req := getCommandBody[json.RawMessage](body)
 
 	ctx, cancel := context.WithCancel(gctx)
 	ctx = context.WithValue(ctx, SESSION_ID_KEY, req.SessionID)
@@ -25,7 +25,9 @@ func handle(gctx global.Context, name string, body []byte) error {
 
 	switch name {
 	case "userstate", "cosmetics":
-		err = handleUserState(gctx, ctx, req.Body)
+		err = handleUserState(gctx, ctx, getCommandBody[events.UserStateCommandBody](body))
+	case "presence":
+		err = handlePresence(gctx, ctx, getCommandBody[events.PresenceCommandBody](body))
 	}
 
 	return err

--- a/internal/api/eventbridge/eventbridge_presence.go
+++ b/internal/api/eventbridge/eventbridge_presence.go
@@ -1,0 +1,67 @@
+package eventbridge
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/seventv/api/data/events"
+	"github.com/seventv/api/data/model"
+	"github.com/seventv/api/internal/global"
+	"github.com/seventv/api/internal/svc/presences"
+	"github.com/seventv/common/errors"
+	"github.com/seventv/common/structures/v3"
+	"github.com/seventv/common/utils"
+	"go.uber.org/zap"
+)
+
+func handlePresence(gctx global.Context, ctx context.Context, cmd events.BridgedCommandPayload[events.PresenceCommandBody]) error {
+	body := cmd.Body
+
+	authentic := !cmd.ActorID.IsZero() && cmd.ActorID == body.UserID
+
+	switch body.Kind {
+	case model.UserPresenceKindChannel:
+		var pd structures.UserPresenceDataChannel
+
+		if err := json.Unmarshal(body.Data, &pd); err != nil {
+			return errors.ErrInvalidRequest().SetDetail("invalid or missing channel presence data: %s", err.Error())
+		}
+
+		if pd.ID == "" {
+			return errors.ErrBadObjectID().SetDetail("missing ID in channel presence data")
+		}
+
+		var known bool
+		if user, err := gctx.Inst().Loaders.UserByConnectionID(pd.Platform).Load(pd.ID); err == nil && !user.ID.IsZero() {
+			known = true
+		}
+
+		pm := gctx.Inst().Presences.ChannelPresence(ctx, cmd.Body.UserID)
+
+		ttl := utils.Ternary(known, time.Hour*24, time.Minute*12) // set lower ttl for an unknown channel
+
+		p, err := pm.Write(ctx, ttl, structures.UserPresenceDataChannel{
+			Platform: pd.Platform,
+			ID:       pd.ID,
+			Filter:   pd.Filter,
+		}, presences.WritePresenceOptions{
+			IP:        cmd.ClientIP,
+			Known:     known,
+			Authentic: authentic,
+		})
+
+		if err != nil {
+			return errors.From(err)
+		}
+
+		if err := gctx.Inst().Presences.ChannelPresenceFanout(ctx, presences.ChannelPresenceFanoutOptions{
+			Presence: p,
+			Whisper:  utils.Ternary(body.Self, cmd.SessionID, ""),
+		}); err != nil {
+			zap.S().Errorw("failed to fanout channel presence", "error", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/api/eventbridge/eventbridge_userstate.go
+++ b/internal/api/eventbridge/eventbridge_userstate.go
@@ -21,7 +21,9 @@ const (
 	identifier_id               = "id"
 )
 
-func handleUserState(gctx global.Context, ctx context.Context, body events.UserStateCommandBody) error {
+func handleUserState(gctx global.Context, ctx context.Context, cmd events.BridgedCommandPayload[events.UserStateCommandBody]) error {
+	body := cmd.Body
+
 	var sid string
 	switch v := ctx.Value(SESSION_ID_KEY).(type) {
 	case string:

--- a/internal/api/rest/v3/routes/users/users.presence.write.go
+++ b/internal/api/rest/v3/routes/users/users.presence.write.go
@@ -96,7 +96,9 @@ func (r *userPresenceWriteRoute) Handler(ctx *rest.Ctx) rest.APIError {
 		presence = p.ToRaw()
 
 		go func() {
-			if err := r.gctx.Inst().Presences.ChannelPresenceFanout(ctx, p); err != nil {
+			if err := r.gctx.Inst().Presences.ChannelPresenceFanout(ctx, presences.ChannelPresenceFanoutOptions{
+				Presence: p,
+			}); err != nil {
 				zap.S().Errorw("failed to fanout channel presence", "error", err)
 			}
 		}()

--- a/internal/svc/presences/presences.go
+++ b/internal/svc/presences/presences.go
@@ -17,7 +17,7 @@ import (
 type Instance interface {
 	// ChannelPresence returns a PresenceManager for the given actorID, with only Channel presence data.
 	ChannelPresence(ctx context.Context, actorID primitive.ObjectID) PresenceManager[structures.UserPresenceDataChannel]
-	ChannelPresenceFanout(ctx context.Context, presence structures.UserPresence[structures.UserPresenceDataChannel]) error
+	ChannelPresenceFanout(ctx context.Context, opt ChannelPresenceFanoutOptions) error
 }
 
 type inst struct {


### PR DESCRIPTION
Adding a `presence` ws-bridged command, as an alternative to the REST route. This can reduce HTTP requests when running under an infrastructure where such are metered.

To facilitate delivery of entitlements to the current user, there is now also a `self` option, which when set true will create a presence that only emits events to the current user, for privacy purposes. (Writing a public presence upon channel join would lead to users becoming trackable)