### PR TITLE
Presence: Private & Passive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.14.0
-	github.com/seventv/common v0.0.0-20230307110704-b1ac005086d9
+	github.com/seventv/common v0.0.0-20230315095517-75880da5f6ce
 	github.com/seventv/compactdisc v0.0.0-20221006190906-ccfe99954e48
 	github.com/seventv/image-processor/go v0.0.0-20221128171540-d050701ac324
 	github.com/seventv/message-queue/go v0.0.0-20220721124044-9fd23bda9643

--- a/go.sum
+++ b/go.sum
@@ -346,6 +346,8 @@ github.com/seventv/common v0.0.0-20230307015448-ab349e095cf8 h1:mBCmLChj9HPy7DKQ
 github.com/seventv/common v0.0.0-20230307015448-ab349e095cf8/go.mod h1:jHHFe3uNMyzb/ReDqMvaI/A1euvV/PW/G+2PhcWQqWw=
 github.com/seventv/common v0.0.0-20230307110704-b1ac005086d9 h1:2G8MQgdA9aMkXAolSzKbHdKZKSIxiuE7tObD8cT3b8A=
 github.com/seventv/common v0.0.0-20230307110704-b1ac005086d9/go.mod h1:jHHFe3uNMyzb/ReDqMvaI/A1euvV/PW/G+2PhcWQqWw=
+github.com/seventv/common v0.0.0-20230315095517-75880da5f6ce h1:6rZ6710n9D9VJdgDmFYICmqQBh/m6E9elxMy4S4lRQE=
+github.com/seventv/common v0.0.0-20230315095517-75880da5f6ce/go.mod h1:jHHFe3uNMyzb/ReDqMvaI/A1euvV/PW/G+2PhcWQqWw=
 github.com/seventv/compactdisc v0.0.0-20221006190906-ccfe99954e48 h1:IqWrtt/yob45YnOQ5Wwkbf8qP22eKVtg0WzfyEkGnFg=
 github.com/seventv/compactdisc v0.0.0-20221006190906-ccfe99954e48/go.mod h1:T+ldp0YQe03s44+A5HHHI/jB3ZmWqOIaNouEqAS+1Dk=
 github.com/seventv/image-processor/go v0.0.0-20221128171540-d050701ac324 h1:iU3wWepRTbkNoTAPR23m6TAW6Yb9pOMCYVr0K++OBAw=

--- a/internal/api/rest/v3/routes/config/config.root.go
+++ b/internal/api/rest/v3/routes/config/config.root.go
@@ -47,8 +47,8 @@ func (r *Route) Handler(ctx *rest.Ctx) rest.APIError {
 	switch name {
 	case "extension":
 		t = sys.Config.Extension
-	case "extension-beta":
-		t = sys.Config.ExtensionBeta
+	case "extension-nightly", "extension-beta":
+		t = sys.Config.ExtensionNightly
 	default:
 		return errors.ErrInvalidRequest().SetDetail("Invalid config name")
 	}

--- a/internal/svc/presences/presences.go
+++ b/internal/svc/presences/presences.go
@@ -17,7 +17,7 @@ import (
 type Instance interface {
 	// ChannelPresence returns a PresenceManager for the given actorID, with only Channel presence data.
 	ChannelPresence(ctx context.Context, actorID primitive.ObjectID) PresenceManager[structures.UserPresenceDataChannel]
-	ChannelPresenceFanout(ctx context.Context, presence structures.UserPresence[structures.UserPresenceDataChannel]) error
+	ChannelPresenceFanout(ctx context.Context, opt ChannelPresenceFanoutOptions) error
 }
 
 type inst struct {

--- a/internal/svc/presences/presences.manager.go
+++ b/internal/svc/presences/presences.manager.go
@@ -79,6 +79,10 @@ func (pm *presenceManager[T]) Write(ctx context.Context, ttl time.Duration, data
 		}
 	}
 
+	if opt.Passive {
+		return p, nil
+	}
+
 	// Write the presence
 	err := pm.inst.mongo.Collection(mongo.CollectionNameUserPresences).FindOneAndUpdate(
 		ctx,
@@ -104,4 +108,5 @@ type WritePresenceOptions struct {
 	Authentic bool
 	Known     bool
 	IP        string
+	Passive   bool
 }


### PR DESCRIPTION
Adding parameters to push presences to a singular event session via REST, and the ability to create passive presences which are not stored in to persistence and do not update entitlement records.