### PR TITLE
fix: bad query shard key at name change logic

### DIFF
--- a/internal/middleware/auth.middleware.go
+++ b/internal/middleware/auth.middleware.go
@@ -59,8 +59,7 @@ func Auth(gctx global.Context) Middleware {
 			oldUsername string
 		)
 
-		if len(user.Connections) > 0 {
-			conn := user.Connections[0]
+		if conn, i, _ := user.Connections.Twitch(); i != -1 {
 			connUsername, connDisplayName := conn.Username()
 
 			usernameDidChange = connUsername != user.Username

--- a/internal/middleware/auth.middleware.go
+++ b/internal/middleware/auth.middleware.go
@@ -55,6 +55,9 @@ func Auth(gctx global.Context) Middleware {
 
 		// Check for username change
 		// Find primary user account
+		var (
+			oldUsername string
+		)
 
 		if len(user.Connections) > 0 {
 			conn := user.Connections[0]
@@ -62,6 +65,7 @@ func Auth(gctx global.Context) Middleware {
 
 			usernameDidChange = connUsername != user.Username
 			if usernameDidChange {
+				oldUsername = user.Username
 				user.Username, user.DisplayName = connUsername, connDisplayName
 
 				user.SetDiscriminator("")
@@ -84,7 +88,8 @@ func Auth(gctx global.Context) Middleware {
 			}
 
 			if _, err := gctx.Inst().Mongo.Collection(mongo.CollectionNameUsers).UpdateOne(gctx, bson.M{
-				"_id": user.ID,
+				"_id":      user.ID,
+				"username": oldUsername,
 			}, bson.M{
 				"$set": m,
 			}); err != nil {

--- a/internal/middleware/auth.middleware.go
+++ b/internal/middleware/auth.middleware.go
@@ -60,6 +60,7 @@ func Auth(gctx global.Context) Middleware {
 		)
 
 		if conn, i, _ := user.Connections.Twitch(); i != -1 {
+			oldUsername = user.Username
 			connUsername, connDisplayName := conn.Username()
 
 			usernameDidChange = connUsername != user.Username


### PR DESCRIPTION
adding the missing shard key during the mutation for name changes, so that name changes can actually work in production