### PR TITLE
fix(rest/user-connection): populate emote-set-id

### DIFF
--- a/data/model/user-connection.model.go
+++ b/data/model/user-connection.model.go
@@ -58,12 +58,15 @@ func (x *modelizer) UserConnection(v structures.UserConnection[bson.Raw]) UserCo
 	username, displayName := v.Username()
 
 	var set *EmoteSetModel
+	var setID *primitive.ObjectID
 
 	if v.EmoteSet != nil {
 		s := x.EmoteSet(*v.EmoteSet)
 		set = &s
+		setID = &v.EmoteSetID
 	} else if !v.EmoteSetID.IsZero() {
 		set = utils.PointerOf(x.EmoteSet(structures.EmoteSet{ID: v.EmoteSetID}))
+		setID = &v.EmoteSetID
 	}
 
 	return UserConnectionModel{
@@ -74,6 +77,7 @@ func (x *modelizer) UserConnection(v structures.UserConnection[bson.Raw]) UserCo
 		LinkedAt:      v.LinkedAt.UnixMilli(),
 		EmoteCapacity: int32(v.EmoteSlots),
 		EmoteSet:      set,
+		EmoteSetID:    setID,
 	}
 }
 

--- a/data/model/user-connection.model.go
+++ b/data/model/user-connection.model.go
@@ -57,8 +57,10 @@ var (
 func (x *modelizer) UserConnection(v structures.UserConnection[bson.Raw]) UserConnectionModel {
 	username, displayName := v.Username()
 
-	var set *EmoteSetModel
-	var setID *primitive.ObjectID
+	var (
+		set   *EmoteSetModel
+		setID *primitive.ObjectID
+	)
 
 	if v.EmoteSet != nil {
 		s := x.EmoteSet(*v.EmoteSet)

--- a/internal/api/rest/v3/routes/users/users.by-connection.go
+++ b/internal/api/rest/v3/routes/users/users.by-connection.go
@@ -131,6 +131,7 @@ func (r *userConnectionRoute) Handler(ctx *rest.Ctx) rest.APIError {
 
 	if !emoteSetModel.ID.IsZero() {
 		userConnModel.EmoteSet = &emoteSetModel
+		userConnModel.EmoteSetID = &emoteSetModel.ID
 	}
 
 	if len(emoteSetModel.Emotes) == 0 {


### PR DESCRIPTION
The `emote_set_id` was never populated. This PR fixes that.